### PR TITLE
Remove black padding when completing small numbers of images

### DIFF
--- a/model.py
+++ b/model.py
@@ -276,7 +276,7 @@ Initializing a new one.
             v = 0
 
             nRows = np.ceil(batchSz/8)
-            nCols = 8
+            nCols = min(8, batchSz)
             save_images(batch_images[:batchSz,:,:,:], [nRows,nCols],
                         os.path.join(config.outDir, 'before.png'))
             masked_images = np.multiply(batch_images, batch_mask)
@@ -307,7 +307,7 @@ Initializing a new one.
                     imgName = os.path.join(config.outDir,
                                            'hats_imgs/{:04d}.png'.format(i))
                     nRows = np.ceil(batchSz/8)
-                    nCols = 8
+                    nCols = min(8, batchSz)
                     save_images(G_imgs[:batchSz,:,:,:], [nRows,nCols], imgName)
 
                     inv_masked_hat_images = np.multiply(G_imgs, 1.0-batch_mask)


### PR DESCRIPTION
Rather than assuming that we always complete in rows of a full 8 images, support shorter rows if <8 images in total.