### PR TITLE
Fixes image_size parameter for training, works for powers of 2 >= 8

### DIFF
--- a/model.py
+++ b/model.py
@@ -132,7 +132,7 @@ class DCGAN(object):
         self.grad_complete_loss = tf.gradients(self.complete_loss, self.z)
 
     def train(self, config):
-        data = glob(os.path.join(config.dataset, "*.png"))
+        data = glob(config.dataset)
         #np.random.shuffle(data)
         assert(len(data) > 0)
 
@@ -183,7 +183,7 @@ Initializing a new one.
 """)
 
         for epoch in xrange(config.epoch):
-            data = glob(os.path.join(config.dataset, "*.png"))
+            data = glob(config.dataset)
             batch_idxs = min(len(data), config.train_size) // self.batch_size
 
             for idx in xrange(0, batch_idxs):
@@ -250,7 +250,6 @@ Initializing a new one.
         isLoaded = self.load(self.checkpoint_dir)
         assert(isLoaded)
 
-        # data = glob(os.path.join(config.dataset, "*.png"))
         nImgs = len(config.imgs)
 
         batch_idxs = int(np.ceil(nImgs/self.batch_size))

--- a/model.py
+++ b/model.py
@@ -20,8 +20,8 @@ SUPPORTED_EXTENSIONS = ["png", "jpg", "jpeg"]
 
 def dataset_files(root):
     """Returns a list of all image files in the given directory"""
-    data = itertools.chain.from_iterable(
-        glob(os.path.join(root, "*.{}".format(ext))) for ext in SUPPORTED_EXTENSIONS)
+    return list(itertools.chain.from_iterable(
+        glob(os.path.join(root, "*.{}".format(ext))) for ext in SUPPORTED_EXTENSIONS))
 
 
 class DCGAN(object):

--- a/model.py
+++ b/model.py
@@ -233,9 +233,14 @@ Initializing a new one.
 
 
     def complete(self, config):
-        os.makedirs(os.path.join(config.outDir, 'hats_imgs'), exist_ok=True)
-        os.makedirs(os.path.join(config.outDir, 'completed'), exist_ok=True)
-        os.makedirs(os.path.join(config.outDir, 'logs'), exist_ok=True)
+        def make_dir(name):
+            # Works on python 2.7, where exist_ok arg to makedirs isn't available.
+            p = os.path.join(config.outDir, name)
+            if not os.path.exists(p):
+                os.makedirs(p)
+        make_dir('hats_imgs')
+        make_dir('completed')
+        make_dir('logs')
 
         try:
             tf.global_variables_initializer().run()


### PR DESCRIPTION
I was not able to get the image_size parameter working when training, it seemed like the code had some hardcoded assumptions about the image size in the generator.

This PR fixes that, but only for cases where the image is square with side lengths that are a power of 2, that is 8 pixels or more.

The generator is parameterised based on the image size, with more upscale/transpose convolutions for more powers of 2.

My assumption is that larger images require more complex models in the discriminator. However, I have not yet found a way to effectively parameterise the discriminator to scale with image size. For now it still works OK for me up to 128, which is as high as I can do with my limited GPU memory.

Other small changes:

- Removes the hardcoded requirement for png images to be input. Maybe don't accept this PR if you don't want people's existing command line args to break (now just uses the glob, rather than accepting a directory).
 - Fixes directory creation on python 2.7
 - Deleted one or two lines of commented code.
 - Turned data shuffling back on.

I won't be offended if you don't accept this PR :) I'm not even close to being an expert. Thank you so much for the original code!